### PR TITLE
Adapt workspace client to default branch renaming

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,27 @@
+name: Yarn build & test
+on:
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node 12
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: 'https://registry.npmjs.org'
+        scope: '@eclipse-che'
+
+    - name: Install dependencies
+      run: yarn
+
+    - name: Build extension
+      run: yarn build
+
+    - name: Run Test
+      run: yarn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to NPM
 on:
   push:
     branches:
-      - "master"
+      - "main"
 
 jobs:
   build:


### PR DESCRIPTION
Adapt workspace client to default branch renaming.
In addition it adds PR check.

It's for https://github.com/eclipse/che/issues/19614