### PR TITLE
Chore: Update GitHub actions to use node 16 and Ubuntu to latest

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ on:
 jobs:
 
   coverage-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: "Checkout workspace-client source code"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
 
   dash-licenses:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: "Checkout workspace-client source code"
@@ -35,7 +35,7 @@ jobs:
         run: yarn license:check
 
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [14.x, 16.x]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,8 @@ on:
       - "main"
 
 jobs:
-
-  build-and-publish:
-    runs-on: ubuntu-20.04
+  build:
+    runs-on: ubuntu-22.04
     steps:
       -
         name: "Checkout workspace-client source code"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
       - "main"
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-22.04
     steps:
       -


### PR DESCRIPTION
Signed-off-by: sdawley <sdawley@redhat.com>

Changes for issue: https://github.com/eclipse/che/issues/21763